### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/filter-lists-breaking-2.txt
+++ b/filter-lists-breaking-2.txt
@@ -1,3 +1,4 @@
+[Adblock Plus 2.0]
 ! Author: Master Inspire
 ! Expires: 7 days (update frequency)
 ! Homepage: https://github.com/masterinspire/filter-lists

--- a/filter-lists-breaking-3.txt
+++ b/filter-lists-breaking-3.txt
@@ -1,3 +1,4 @@
+[Adblock Plus 2.0]
 ! Author: Master Inspire
 ! Expires: 7 days (update frequency)
 ! Homepage: https://github.com/masterinspire/filter-lists

--- a/filter-lists-breaking.txt
+++ b/filter-lists-breaking.txt
@@ -1,3 +1,4 @@
+[Adblock Plus 2.0]
 ! Author: Master Inspire
 ! Expires: 7 days (update frequency)
 ! Homepage: https://github.com/masterinspire/filter-lists

--- a/filter-lists.txt
+++ b/filter-lists.txt
@@ -1,3 +1,4 @@
+[Adblock Plus 2.0]
 ! Author: Master Inspire
 ! Expires: 3 days (update frequency)
 ! Homepage: https://github.com/masterinspire/filter-lists


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401